### PR TITLE
feat: 북마크 기능 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 ### Kotlin ###
 .kotlin
 application-local.yml
+
+### Test ###
+http/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,8 +43,10 @@ dependencies {
     annotationProcessor("org.projectlombok:lombok")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.security:spring-security-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testRuntimeOnly("com.h2database:h2")
 }
 
 kotlin {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("org.jsoup:jsoup:1.17.2")
 
     // oauth
     implementation("org.springframework.boot:spring-boot-starter-security")
@@ -41,6 +42,9 @@ dependencies {
     // lombok
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")
+
+    // logging
+    implementation("io.github.oshai:kotlin-logging-jvm:7.0.13")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")

--- a/src/main/kotlin/com/yhproject/mywiki/auth/CustomOAuth2UserService.kt
+++ b/src/main/kotlin/com/yhproject/mywiki/auth/CustomOAuth2UserService.kt
@@ -2,21 +2,16 @@ package com.yhproject.mywiki.auth
 
 import com.yhproject.mywiki.domain.user.User
 import com.yhproject.mywiki.domain.user.UserRepository
-import jakarta.servlet.http.HttpSession
-import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService
-import org.springframework.security.oauth2.core.user.DefaultOAuth2User
 import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.util.Collections
 
 @Service
 class CustomOAuth2UserService(
-    private val userRepository: UserRepository,
-    private val httpSession: HttpSession
+    private val userRepository: UserRepository
 ) : OAuth2UserService<OAuth2UserRequest, OAuth2User> {
 
     @Transactional
@@ -35,12 +30,10 @@ class CustomOAuth2UserService(
 
         val user = saveOrUpdate(attributes)
 
-        httpSession.setAttribute("user", SessionUser(user))
-
-        return DefaultOAuth2User(
-            Collections.singleton(SimpleGrantedAuthority(user.role.key)),
-            attributes.attributes,
-            attributes.nameAttributeKey
+        return PrincipalDetails(
+            user = user,
+            attributes = attributes.attributes,
+            nameAttributeKey = attributes.nameAttributeKey
         )
     }
 

--- a/src/main/kotlin/com/yhproject/mywiki/auth/LoginUser.kt
+++ b/src/main/kotlin/com/yhproject/mywiki/auth/LoginUser.kt
@@ -1,0 +1,8 @@
+package com.yhproject.mywiki.auth
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@AuthenticationPrincipal(expression = "sessionUser")
+annotation class LoginUser

--- a/src/main/kotlin/com/yhproject/mywiki/auth/PrincipalDetails.kt
+++ b/src/main/kotlin/com/yhproject/mywiki/auth/PrincipalDetails.kt
@@ -1,0 +1,55 @@
+package com.yhproject.mywiki.auth
+
+import com.yhproject.mywiki.domain.user.User
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.userdetails.UserDetails
+import org.springframework.security.oauth2.core.user.OAuth2User
+
+class PrincipalDetails(
+    val user: User,
+    private val attributes: Map<String, Any>,
+    private val nameAttributeKey: String
+) : UserDetails, OAuth2User {
+
+    val sessionUser: SessionUser = SessionUser(user)
+
+    // OAuth2User methods
+    override fun getName(): String {
+        return attributes[nameAttributeKey].toString()
+    }
+
+    override fun getAttributes(): Map<String, Any> {
+        return attributes
+    }
+
+    // UserDetails methods
+    override fun getPassword(): String? {
+        return null
+    }
+
+    override fun getUsername(): String {
+        return user.email
+    }
+
+    override fun isAccountNonExpired(): Boolean {
+        return true
+    }
+
+    override fun isAccountNonLocked(): Boolean {
+        return true
+    }
+
+    override fun isCredentialsNonExpired(): Boolean {
+        return true
+    }
+
+    override fun isEnabled(): Boolean {
+        return true
+    }
+
+    // Common method for both interfaces
+    override fun getAuthorities(): Collection<GrantedAuthority> {
+        return setOf(SimpleGrantedAuthority(user.role.key))
+    }
+}

--- a/src/main/kotlin/com/yhproject/mywiki/auth/SessionUser.kt
+++ b/src/main/kotlin/com/yhproject/mywiki/auth/SessionUser.kt
@@ -4,8 +4,8 @@ import com.yhproject.mywiki.domain.user.User
 import java.io.Serializable
 
 data class SessionUser(
-    val name: String,
-    val email: String
+    val id: Long,
+    val name: String
 ) : Serializable {
-    constructor(user: User) : this(user.name, user.email)
+    constructor(user: User) : this(user.id, user.name)
 }

--- a/src/main/kotlin/com/yhproject/mywiki/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/yhproject/mywiki/config/SecurityConfig.kt
@@ -3,6 +3,7 @@ package com.yhproject.mywiki.config
 import com.yhproject.mywiki.auth.CustomOAuth2UserService
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpStatus
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.web.SecurityFilterChain
@@ -10,24 +11,35 @@ import org.springframework.security.web.SecurityFilterChain
 @Configuration
 @EnableWebSecurity
 class SecurityConfig(
-    private val customOAuth2UserService: CustomOAuth2UserService
+    private val customOAuth2UserService: CustomOAuth2UserService,
 ) {
 
     @Bean
     fun filterChain(http: HttpSecurity): SecurityFilterChain {
         http
             .csrf { it.disable() }
-            .authorizeHttpRequests { auth ->
-                auth
+            .headers { it.frameOptions { frameOptions -> frameOptions.disable() } }
+            .authorizeHttpRequests {
+                it
                     .requestMatchers("/", "/css/**", "/images/**", "/js/**", "/h2-console/**", "/error").permitAll()
-                    .requestMatchers("/api/v1/**").hasRole("USER")
+                    .requestMatchers("/api/**").hasRole("USER")
                     .anyRequest().authenticated()
             }
-            .logout { logout -> logout.logoutSuccessUrl("/") }
-            .oauth2Login { oauth2 ->
-                oauth2.userInfoEndpoint { userInfo ->
-                    userInfo.userService(customOAuth2UserService)
+            .logout { it.logoutSuccessUrl("/") }
+            .oauth2Login {
+                it.userInfoEndpoint {
+                    it.userService(customOAuth2UserService)
                 }
+            }
+            .exceptionHandling { handler ->
+                handler.defaultAuthenticationEntryPointFor(
+                    { _, response, _ ->
+                        response.status = HttpStatus.UNAUTHORIZED.value()
+                    },
+                    { request ->
+                        request.requestURI.startsWith("/api/")
+                    }
+                )
             }
 
         return http.build()

--- a/src/main/kotlin/com/yhproject/mywiki/controller/BookmarkController.kt
+++ b/src/main/kotlin/com/yhproject/mywiki/controller/BookmarkController.kt
@@ -1,0 +1,31 @@
+package com.yhproject.mywiki.controller
+
+import com.yhproject.mywiki.auth.LoginUser
+import com.yhproject.mywiki.auth.SessionUser
+import com.yhproject.mywiki.dto.BookmarkCreateRequest
+import com.yhproject.mywiki.dto.BookmarkResponse
+import com.yhproject.mywiki.service.BookmarkService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/bookmarks")
+class BookmarkController(
+    private val bookmarkService: BookmarkService
+) {
+
+    @PostMapping
+    fun createBookmark(
+        @RequestBody request: BookmarkCreateRequest,
+        @LoginUser sessionUser: SessionUser
+    ): ResponseEntity<BookmarkResponse> {
+        val bookmark = bookmarkService.createBookmark(request, sessionUser)
+        return ResponseEntity.ok(bookmark)
+    }
+
+    @GetMapping
+    fun getBookmarks(@LoginUser sessionUser: SessionUser): ResponseEntity<List<BookmarkResponse>> {
+        val bookmarks = bookmarkService.getBookmarks(sessionUser)
+        return ResponseEntity.ok(bookmarks)
+    }
+}

--- a/src/main/kotlin/com/yhproject/mywiki/domain/bookmark/Bookmark.kt
+++ b/src/main/kotlin/com/yhproject/mywiki/domain/bookmark/Bookmark.kt
@@ -1,0 +1,34 @@
+package com.yhproject.mywiki.domain.bookmark
+
+import com.yhproject.mywiki.domain.user.User
+import jakarta.persistence.*
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "bookmarks")
+class Bookmark(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: User,
+
+    @Column(nullable = false)
+    var url: String,
+
+    val title: String,
+
+    val description: String,
+
+    val image: String,
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime = LocalDateTime.now()
+) {
+    protected constructor() : this(0, User(), "", "", "", "", LocalDateTime.now(), LocalDateTime.now())
+}

--- a/src/main/kotlin/com/yhproject/mywiki/domain/bookmark/BookmarkRepository.kt
+++ b/src/main/kotlin/com/yhproject/mywiki/domain/bookmark/BookmarkRepository.kt
@@ -1,0 +1,7 @@
+package com.yhproject.mywiki.domain.bookmark
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface BookmarkRepository : JpaRepository<Bookmark, Long> {
+    fun findAllByUserId(userId: Long): List<Bookmark>
+}

--- a/src/main/kotlin/com/yhproject/mywiki/domain/user/User.kt
+++ b/src/main/kotlin/com/yhproject/mywiki/domain/user/User.kt
@@ -30,7 +30,7 @@ class User(
     @Column(name = "updated_at", nullable = false)
     var updatedAt: LocalDateTime = LocalDateTime.now()
 ) {
-    protected constructor() : this(0, "", "", Role.GUEST, "", "", LocalDateTime.now(), LocalDateTime.now())
+    internal constructor() : this(0, "", "", Role.GUEST, "", "", LocalDateTime.now(), LocalDateTime.now())
 
     fun update(name: String): User {
         this.name = name

--- a/src/main/kotlin/com/yhproject/mywiki/dto/BookmarkDto.kt
+++ b/src/main/kotlin/com/yhproject/mywiki/dto/BookmarkDto.kt
@@ -1,0 +1,25 @@
+package com.yhproject.mywiki.dto
+
+import com.yhproject.mywiki.domain.bookmark.Bookmark
+
+data class BookmarkCreateRequest(
+    val url: String
+)
+
+data class BookmarkResponse(
+    val id: Long,
+    val url: String,
+    val title: String,
+    val description: String,
+    val image: String
+) {
+    companion object {
+        fun from(bookmark: Bookmark): BookmarkResponse = BookmarkResponse(
+            id = bookmark.id,
+            url = bookmark.url,
+            title = bookmark.title,
+            description = bookmark.description,
+            image = bookmark.image
+        )
+    }
+}

--- a/src/main/kotlin/com/yhproject/mywiki/service/BookmarkService.kt
+++ b/src/main/kotlin/com/yhproject/mywiki/service/BookmarkService.kt
@@ -1,0 +1,92 @@
+package com.yhproject.mywiki.service
+
+import com.yhproject.mywiki.auth.SessionUser
+import com.yhproject.mywiki.domain.bookmark.Bookmark
+import com.yhproject.mywiki.domain.bookmark.BookmarkRepository
+import com.yhproject.mywiki.domain.user.User
+import com.yhproject.mywiki.domain.user.UserRepository
+import com.yhproject.mywiki.dto.BookmarkCreateRequest
+import com.yhproject.mywiki.dto.BookmarkResponse
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.jsoup.Jsoup
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class BookmarkService(
+    private val bookmarkRepository: BookmarkRepository,
+    private val userRepository: UserRepository
+) {
+    private val logger = KotlinLogging.logger {}
+
+    @Transactional
+    fun createBookmark(request: BookmarkCreateRequest, sessionUser: SessionUser): BookmarkResponse {
+        val user = findUserById(sessionUser.id)
+
+        // REFACTOR: 성능 이슈가 있으면 비동기로 전환
+        val documentMetadata = getDocumentMetadata(request.url)
+
+        val bookmark = Bookmark(
+            user = user,
+            url = request.url,
+            title = documentMetadata.title,
+            description = documentMetadata.description,
+            image = documentMetadata.image
+        )
+
+        val savedBookmark = bookmarkRepository.save(bookmark)
+        return BookmarkResponse.from(savedBookmark)
+    }
+
+    @Transactional(readOnly = true)
+    fun getBookmarks(sessionUser: SessionUser): List<BookmarkResponse> {
+        val user = findUserById(sessionUser.id)
+
+        return bookmarkRepository.findAllByUserId(user.id)
+            .map { BookmarkResponse.from(it) }
+    }
+
+    private fun findUserById(userId: Long): User {
+        return userRepository.findById(userId)
+            .orElseThrow { IllegalArgumentException("User not found with id: $userId") }
+    }
+
+    private fun getDocumentMetadata(url: String): DocumentMetadata {
+        // url에 해당하는 html을 get 하여 metadata를 조회
+        // title, description, image 메타데이터 획득
+        try {
+            val doc = Jsoup.connect(url)
+                .timeout(5000) // 5초 타임아웃
+                .get()
+
+            // 1. Open Graph 태그 우선 조회
+            val title = doc.select("meta[property=og:title]").attr("content").ifEmpty {
+                // 2. og:title이 없으면 <title> 태그 조회
+                doc.title()
+            }
+            val description = doc.select("meta[property=og:description]").attr("content").ifEmpty {
+                // 3. og:description이 없으면 <meta name="description"> 조회
+                doc.select("meta[name=description]").attr("content")
+            }
+            val image = doc.select("meta[property=og:image]").attr("content")
+
+            return DocumentMetadata(
+                // 만약 제목이 비어있다면 URL을 기본값으로 사용
+                title = title.ifEmpty { url },
+                description = description,
+                image = image
+            )
+        } catch (e: Exception) {
+            logger.error { "Error fetching metadata from url: $url, error: ${e.message}" }
+            // 메타데이터 조회 실패 시, URL을 제목으로 하는 기본 데이터를 반환
+            // REFACTOR: 일시적인 조회 실패라면? 나중에라도 데이터를 넣고 싶다면 어느 시점에 재시도할 것인가?
+            return DocumentMetadata(title = url, description = "", image = "")
+        }
+    }
+
+    data class DocumentMetadata(
+        val title: String,
+        val description: String,
+        val image: String
+    )
+}

--- a/src/test/kotlin/com/yhproject/mywiki/auth/SecurityTest.kt
+++ b/src/test/kotlin/com/yhproject/mywiki/auth/SecurityTest.kt
@@ -1,0 +1,51 @@
+package com.yhproject.mywiki.auth
+
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class SecurityTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    @DisplayName("인증되지 않은 사용자가 보호된 API를 호출하면 401 에러를 반환한다")
+    fun `unauthenticated user is redirected to login page`() {
+        mockMvc.perform(get("/api/v1/user/me"))
+            .andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    @WithMockUser(roles = ["USER"])
+    @DisplayName("USER 권한의 사용자는 보호된 API를 호출할 수 있다")
+    fun `user with USER role can access protected api`() {
+        mockMvc.perform(get("/api/v1/user/me"))
+            .andExpect(status().isOk)
+    }
+
+    @Test
+    @WithMockUser(roles = ["GUEST"])
+    @DisplayName("GUEST 권한의 사용자는 보호된 API를 호출할 수 없다")
+    fun `user with GUEST role cannot access protected api`() {
+        mockMvc.perform(get("/api/v1/user/me"))
+            .andExpect(status().isForbidden)
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("로그아웃을 호출하면 루트 페이지로 리디렉션된다")
+    fun `logout redirects to root page`() {
+        mockMvc.perform(get("/logout"))
+            .andExpect(status().is3xxRedirection)
+            .andExpect(redirectedUrl("/"))
+    }
+}

--- a/src/test/kotlin/com/yhproject/mywiki/controller/BookmarkControllerTest.kt
+++ b/src/test/kotlin/com/yhproject/mywiki/controller/BookmarkControllerTest.kt
@@ -1,0 +1,127 @@
+package com.yhproject.mywiki.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.yhproject.mywiki.auth.CustomOAuth2UserService
+import com.yhproject.mywiki.auth.PrincipalDetails
+import com.yhproject.mywiki.config.SecurityConfig
+import com.yhproject.mywiki.domain.user.Role
+import com.yhproject.mywiki.domain.user.User
+import com.yhproject.mywiki.dto.BookmarkCreateRequest
+import com.yhproject.mywiki.dto.BookmarkResponse
+import com.yhproject.mywiki.service.BookmarkService
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
+import org.mockito.BDDMockito.verify
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(controllers = [BookmarkController::class])
+@Import(SecurityConfig::class)
+class BookmarkControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @MockitoBean
+    private lateinit var bookmarkService: BookmarkService
+
+    @MockitoBean
+    private lateinit var customOAuth2UserService: CustomOAuth2UserService
+
+    private lateinit var principal: PrincipalDetails
+
+    @BeforeEach
+    fun setUp() {
+        val user = User(
+            id = 1L,
+            name = "testuser",
+            email = "test@email.com",
+            role = Role.USER,
+            provider = "google",
+            providerId = "12345"
+        )
+        principal = PrincipalDetails(user, emptyMap(), "sub")
+    }
+
+    @Test
+    @DisplayName("북마크 생성 요청을 보내면 생성된 북마크 정보를 반환한다")
+    fun `createBookmark returns created bookmark`() {
+        // given
+        val sessionUser = principal.sessionUser
+        val request = BookmarkCreateRequest(url = "https://example.com")
+        val response = BookmarkResponse(1L, "https://example.com", "Test Title", "Test Description", "image.png")
+
+        given(bookmarkService.createBookmark(request, sessionUser)).willReturn(response)
+
+        // when & then
+        mockMvc.perform(
+            post("/api/bookmarks")
+                .with(user(principal))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        )
+            .andExpect(status().isOk)
+            .andExpect(content().json(objectMapper.writeValueAsString(response)))
+
+        verify(bookmarkService).createBookmark(request, sessionUser)
+    }
+
+    @Test
+    @DisplayName("북마크 목록 조회 요청을 보내면 북마크 리스트를 반환한다")
+    fun `getBookmarks returns bookmark list`() {
+        // given
+        val sessionUser = principal.sessionUser
+        val bookmarks = listOf(
+            BookmarkResponse(1L, "https://example.com", "Test Title", "Test Description", "image.png"),
+            BookmarkResponse(2L, "https://example2.com", "Test Title 2", "Test Description 2", "image2.png")
+        )
+        given(bookmarkService.getBookmarks(sessionUser)).willReturn(bookmarks)
+
+        // when & then
+        mockMvc.perform(
+            get("/api/bookmarks")
+                .with(user(principal))
+        )
+            .andExpect(status().isOk)
+            .andExpect(content().json(objectMapper.writeValueAsString(bookmarks)))
+
+        verify(bookmarkService).getBookmarks(sessionUser)
+    }
+
+    @Test
+    @DisplayName("인증 정보 없이 북마크 생성을 요청하면 401 에러를 반환한다")
+    fun `createBookmark without authentication returns 401`() {
+        // given
+        val request = BookmarkCreateRequest(url = "https://example.com")
+
+        // when & then
+        mockMvc.perform(
+            post("/api/bookmarks")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        )
+            .andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    @DisplayName("인증 정보 없이 북마크 목록 조회를 요청하면 401 에러를 반환한다")
+    fun `getBookmarks without authentication returns 401`() {
+        // when & then
+        mockMvc.perform(get("/api/bookmarks"))
+            .andExpect(status().isUnauthorized)
+    }
+}

--- a/src/test/kotlin/com/yhproject/mywiki/controller/UserControllerTest.kt
+++ b/src/test/kotlin/com/yhproject/mywiki/controller/UserControllerTest.kt
@@ -1,0 +1,65 @@
+package com.yhproject.mywiki.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.yhproject.mywiki.auth.CustomOAuth2UserService
+import com.yhproject.mywiki.auth.SessionUser
+import com.yhproject.mywiki.config.SecurityConfig
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.mock.web.MockHttpSession
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(controllers = [UserController::class])
+@Import(SecurityConfig::class)
+@WithMockUser(roles = ["USER"])
+class UserControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @MockitoBean
+    private lateinit var customOAuth2UserService: CustomOAuth2UserService
+
+    private lateinit var sessionUser: SessionUser
+    private lateinit var mockHttpSession: MockHttpSession
+
+    @BeforeEach
+    fun setUp() {
+        sessionUser = SessionUser(1L, "testuser")
+        mockHttpSession = MockHttpSession()
+        mockHttpSession.setAttribute("user", sessionUser)
+    }
+
+    @Test
+    @DisplayName("내 정보를 요청하면 세션에 저장된 사용자 정보를 반환한다")
+    fun `getMyInfo returns user info from session`() {
+        // when & then
+        mockMvc.perform(
+            get("/api/v1/user/me")
+                .session(mockHttpSession)
+        )
+            .andExpect(status().isOk)
+            .andExpect(content().json(objectMapper.writeValueAsString(sessionUser)))
+    }
+
+    @Test
+    @DisplayName("세션에 사용자 정보가 없으면 null을 반환한다")
+    fun `getMyInfo returns null if no user in session`() {
+        // when & then
+        mockMvc.perform(get("/api/v1/user/me")) // 세션 없이 호출
+            .andExpect(status().isOk)
+            .andExpect(content().string("")) // 컨트롤러가 null을 반환하면 body는 비어있음
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,23 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+    defer-datasource-initialization: true
+
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: test
+            client-secret: test
+            scope: profile,email


### PR DESCRIPTION
- user db 조회 용이성을 위해 user session에 userId(PK) 값을 추가
- user 데이터 조회를 http session 다이렉트 조회가 아닌 spring security context 조회 기반으로 변경 (security 호환성 고려)
- 북마크 도메인 및 API 구현
- user, bookmark 도메인 관련 테스트 코드 추가

#8, Closes #11